### PR TITLE
BAU: Added `secretsmanager|SecretString` to `keyword_exclude`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -41,7 +41,7 @@
     },
     {
       "name": "KeywordDetector",
-      "keyword_exclude": ""
+      "keyword_exclude": "secretsmanager|SecretString"
     },
     {
       "name": "MailchimpDetector"
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -105,46 +109,12 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": []
     }
   ],
-  "results": {
-    "deploy/template.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
-        "is_verified": false,
-        "line_number": 57
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
-        "is_verified": false,
-        "line_number": 65
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
-        "is_verified": false,
-        "line_number": 392
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
-        "is_verified": false,
-        "line_number": 393
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
-        "is_verified": false,
-        "line_number": 398
-      }
-    ]
-  },
-  "generated_at": "2023-11-28T14:37:29Z"
+  "results": {},
+  "generated_at": "2023-11-28T15:51:15Z"
 }


### PR DESCRIPTION
### Why did it change
Added `secretsmanager|SecretString` to `keyword_exclude` because the detect-secrets scan will always fail when the word contains "secret" so when referencing something like  SecretsManager in the template.yaml it'll complain. Whenever we modify the template.yaml we are then always required to run secrets-baseline scan since the line numbers change.