### PR TITLE
IPS-493: Update post-merge workflow to use devplatform-upload-action-…

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
 
@@ -33,36 +33,15 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE} || exit 1
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-
-      - name: Update SAM template
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA|" template.yaml
-
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
 
-      - name: Create cf-template.yaml and zip
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sam build
-          mv .aws-sam/build/template.yaml cf-template.yaml
-          zip template.zip cf-template.yaml
-
-      - name: Upload CloudFormation artifacts to S3
-        env:
-          ARTIFACT_BUCKET: ${{ secrets.BUILD_ARTIFACT_BUCKET }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+      - name: Deploy SAM app to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
+        with:
+          artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_BUCKET }}
+          working-directory: .
+          docker-build-path: .
+          template-file: deploy/template.yaml
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY }}

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
 
@@ -34,36 +34,15 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          DEV_ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          DEV_ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE} || exit 1
-          docker build -t $DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$GITHUB_SHA .
-          docker push $DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$GITHUB_SHA
-
-      - name: Update SAM template
-        env:
-          DEV_ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          DEV_ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$GITHUB_SHA|" template.yaml
-
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
 
-      - name: Create cf-template.yaml and zip
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sam build
-          mv .aws-sam/build/template.yaml cf-template.yaml
-          zip template.zip cf-template.yaml
-
-      - name: Upload CloudFormation artifacts to S3
-        env:
-          DEV_ARTIFACT_BUCKET: ${{ secrets.DEV_ARTIFACT_BUCKET }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          aws s3 cp template.zip "s3://$DEV_ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+      - name: Deploy SAM app to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
+        with:
+          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET }}
+          working-directory: .
+          docker-build-path: .
+          template-file: deploy/template.yaml
+          role-to-assume-arn: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.DEV_ECR_REPOSITORY }}


### PR DESCRIPTION
### What changed

- Updated post-merge workflow to use devplatform-upload-action-ecr@1.2.0

### Why did it change

- Required for canary deployments across Identity

### Issue tracking
- [IPS-493](https://govukverify.atlassian.net/browse/IPS-493)
- [IPS-532](https://govukverify.atlassian.net/browse/IPS-532)

## Checklists

### Evidence

- Image successfully pushed to dev, with commit tag, by manually triggering workflow:
https://github.com/govuk-one-login/ipv-cri-kbv-front/actions/runs/7932276700

![image](https://github.com/govuk-one-login/ipv-cri-kbv-front/assets/153090281/da967db1-679a-49e0-a77a-94ab64f6f1a5)


### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-493]: https://govukverify.atlassian.net/browse/IPS-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-532]: https://govukverify.atlassian.net/browse/IPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ