### PR TITLE
IPS-736 Orange CloudFront LB Name

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -180,6 +180,7 @@ Resources:
   LoadBalancer:
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
     Properties:
+      Name: !Sub "${AWS::StackName}-LB-${Environment}"
       Scheme: internal
       SecurityGroups:
         - !GetAtt LoadBalancerSG.GroupId


### PR DESCRIPTION
## Proposed changes

### What changed

Added the load balancer name

### Why did it change

The default name can change which will prevent the cloud-front distribution from connecting to the environment. Having a fixed name will solve this issue.

### Issue tracking

- [OJ-736](https://govukverify.atlassian.net/browse/OJ-736)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed



[OJ-736]: https://govukverify.atlassian.net/browse/OJ-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ