### PR TITLE
OJ-2724: render error page if `redirect_uri` is not present

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -136,4 +136,12 @@ router.use("^/$", (req, res) => {
   res.render("index");
 });
 
+router.use((err, req, res, next) => {
+  if (req.session?.authParams?.redirect_uri) {
+    next(err);
+  } else {
+    res.render("error");
+  }
+});
+
 router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);


### PR DESCRIPTION
## Proposed changes

### What changed
Created a new handler to redirect to error page when `redirect_uri` is undefined.
The fix has been taken from [bav-front](https://github.com/govuk-one-login/ipv-cri-bav-front/blob/5f3f22a211b1a3cd38d36d40b75083d0a5053c91/src/app.js#L160)

### Why did it change
An exception is being thrown in the code when the `redirect_uri` is undefined: `/kbv/question Cannot read properties of undefined (reading 'redirect_uri')` and because of this exception, users are not routed to an appropriate error screen.

### Issue tracking
- [OJ-2724](https://govukverify.atlassian.net/browse/OJ-2724)



[OJ-2724]: https://govukverify.atlassian.net/browse/OJ-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ