### PR TITLE
OJ-2724: Move `redirectAsErrorToCallback`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -139,9 +139,8 @@ router.use("^/$", (req, res) => {
 router.use((err, req, res, next) => {
   if (req.session?.authParams?.redirect_uri) {
     next(err);
+    router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);
   } else {
     res.render("error");
   }
 });
-
-router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);


### PR DESCRIPTION
## Proposed changes

### What changed
Moved `router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);` under `next(err);`

### Why did it change
A fix was added to the redirect_uri undefined error as part of https://github.com/govuk-one-login/ipv-cri-kbv-front/pull/1062

The issue is still persisting so suspecting it's because of `router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);` being in the wrong place. This has been moved so that we're the same as bav front.

### Issue tracking
- [OJ-2724](https://govukverify.atlassian.net/browse/OJ-2724)
