### PR TITLE
Revert "OJ-2724: render error page if `redirect_uri` is not present"

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -136,12 +136,4 @@ router.use("^/$", (req, res) => {
   res.render("index");
 });
 
-router.use((err, req, res, next) => {
-  if (req.session?.authParams?.redirect_uri) {
-    next(err);
-  } else {
-    res.render("error");
-  }
-});
-
 router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);


### PR DESCRIPTION
Reverts govuk-one-login/ipv-cri-kbv-front#1062

This PR did not work and the fix will now be implemented in common-express as it's effecting multiple CRIs. 
https://github.com/govuk-one-login/ipv-cri-common-express/pull/398