### PR TITLE
OJ-2600: Adds missing RetentionInDays to log group

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -620,6 +620,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-KBVFront-API-GW-AccessLogs
+      RetentionInDays: 30
 
   APIGWAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds missing RetentionInDays to log group

### Why did it change

So that they are not retained for infinity

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2600](https://govukverify.atlassian.net/browse/OJ-2600)




[OJ-2600]: https://govukverify.atlassian.net/browse/OJ-2600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ