### PR TITLE
OJ-2777: Fix TypeError on saving a non-existent question

### DIFF
--- a/src/app/kbv/controllers/question.js
+++ b/src/app/kbv/controllers/question.js
@@ -43,6 +43,9 @@ class QuestionController extends BaseController {
       if (err) {
         next(err);
       }
+      if (!req.session.question) {
+        callback(new Error("Current session has no Question to save."));
+      }
 
       const answerHeaders = {
         "session-id": req.session.tokenId,

--- a/src/app/kbv/controllers/question.js
+++ b/src/app/kbv/controllers/question.js
@@ -10,6 +10,9 @@ const { API } = require("../../../lib/config");
 
 class QuestionController extends BaseController {
   configure(req, res, next) {
+    if (!req.session.question) {
+      return next(new Error("Current session has no Question to configure."));
+    }
     const fallbackTranslations = dynamicQuestion.questionToTranslations(
       req.session.question
     );

--- a/src/app/kbv/controllers/question.test.js
+++ b/src/app/kbv/controllers/question.test.js
@@ -213,6 +213,27 @@ describe("Question controller", () => {
       });
     });
 
+    context("with no current session question", () => {
+      beforeEach(async () => {
+        req.session.question = undefined;
+      });
+
+      it("should call next with an error", async () => {
+        await questionController.saveValues(req, res, next);
+
+        expect(next).to.have.been.calledWith(
+          sinon.match
+            .instanceOf(Error)
+            .and(
+              sinon.match.has(
+                "message",
+                "Current session has no Question to save."
+              )
+            )
+        );
+      });
+    });
+
     context("on post answer error", () => {
       let error;
 


### PR DESCRIPTION
## Proposed changes
see: [OJ-2777](https://govukverify.atlassian.net/browse/OJ-2777)
This PR handles TypeError that can occur in the Question Controller,  the error `Cannot read properties of undefined (reading 'questionID')` in dynatrace the error is now caught and explicitly handled.

It is suspected that the user maybe on this Question page for longer than expected

![image](https://github.com/user-attachments/assets/9e8a55a6-bc6a-481a-a4d7-d81d9d288b1b)

the error is likely to occur when they click continue.

It is also possible for the error to occur during Question Controller configure, so this has been replicated in code and handled as well.

During logging it is expected that TypeError would not occur, but these handled errors and it will be possible to determine exactly what point this error occurs i.e. in the Question Controller `save` or `configure`.

If TypeError due to Question not properly initialise still occur then, it will be coming from somewhere else.

see: https://govukverify.atlassian.net/browse/OJ-2777

**NB**: This PR doesn't address the why or how exactly the errors, there will be other tickets to look into the issue

[OJ-2777]: https://govukverify.atlassian.net/browse/OJ-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ