### PR TITLE
IPS-1123 Use dev-platform action to sign images

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -34,12 +34,13 @@ jobs:
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate -t deploy/template.yaml
 
       - name: Deploy SAM app to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@v1.2.6
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_BUCKET }}
+          container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGNING_ARN }}
           working-directory: .
           docker-build-path: .
           template-file: deploy/template.yaml

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -37,12 +37,13 @@ jobs:
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate -t deploy/template.yaml
 
       - name: Deploy SAM app to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@v1.2.6
+        uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0
         with:
           artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET }}
+          container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGNING_ARN }}
           working-directory: .
           docker-build-path: .
           template-file: deploy/template.yaml


### PR DESCRIPTION
## Proposed changes

### What changed

Update workflows to do the container signing and removed misleading empty region configuration from sam commands

### Why did it change

Container signing is now enforced so deployments will fail without

### Issue tracking

- [IPS-1123](https://govukverify.atlassian.net/browse/IPS-1123)

## Checklists

### Environment variables or secrets

- [X] Added to deployment repository



[IPS-1123]: https://govukverify.atlassian.net/browse/IPS-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ