### PR TITLE
Updating GitHub provided action to new version

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Archive coverage results
         if: ${{ inputs.coverage-report }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.coverage-artifact }}
           retention-days: 3

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@145049ebd9a33e57da9a852847c4ee2c8970ea51
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +40,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@145049ebd9a33e57da9a852847c4ee2c8970ea51
+        uses: govuk-one-login/github-actions/code-quality/codeql@d4ec36f4ed5ebfb93d4866b3322a70b27bb8f92f #31st Jan 2024
         with:
           languages: javascript

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +40,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@d4ec36f4ed5ebfb93d4866b3322a70b27bb8f92f #31st Jan 2024
+        uses: govuk-one-login/github-actions/code-quality/codeql@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           languages: javascript


### PR DESCRIPTION
EOL on the 5th December 2024

Also updated version of Sonar Cloud as it needs to use download-artifact v4 as well

https://govukverify.atlassian.net/browse/PSREDEV-1911

## Proposed changes
https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new
https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new

### What changed

Updated GH actions

### Why did it change

V3 being EOLed 5th Dec

### Issue tracking
https://govukverify.atlassian.net/browse/PSREDEV-1911