### PR TITLE
OJ-2872: Add 5xx FE Api Gateway 80 percent error alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -48,6 +48,11 @@ Parameters:
     Default: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/experian-kbv-credential-issuer-runbook/#experian-knowledge-based-verification-kbv-credential-issuer-runbook"
     Description: The support manual URL to be provided in alarm messages.
 
+  DeployAlarmsInDevEnvironment:
+    Description: "Set to the string value `true` to deploy alarms in a DEV environment"
+    Type: String
+    Default: false
+
 Conditions:
   IsNotDevelopment: !Or
     - !Equals [!Ref Environment, build]
@@ -75,6 +80,9 @@ Conditions:
 
   UseCanaryDeployment: !Not
     - !Equals [!Ref DeploymentStrategy, "None"]
+  DeployAlarms: !Or
+    - !Condition IsNotDevelopment
+    - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
 
 Mappings:
   EnvironmentConfiguration:
@@ -615,6 +623,56 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref APIGWAccessLogsGroup
 
+  ExperianKBVFE5XXErrorCriticalAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-ExperianKBVFE5XXErrorCriticalAlarm"
+      AlarmDescription: !Sub "Threshold exceeds 80% with a minimum of 10 invocations in 2 out of the last 5 evaluation periods. ${SupportManualURL}"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      OKActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+        - !ImportValue platform-alarm-critical-alert-topic
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 80
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations >= 10, errorPercentage, 0)
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error / invocations) * 100
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5xx
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+
   # Autoscaling
   # The number of pods will increase when the configured CPU utilization is breached for more than 3 minutes.
   # Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.
@@ -776,6 +834,7 @@ Resources:
 
   ExperianKBVNoTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${AWS::StackName}-${Environment}-ExperianKBVNoTaskCountAlarm
       AlarmDescription: !Sub Experian KBV ${Environment} frontend no ECS service tasks. ${SupportManualURL}
@@ -799,6 +858,7 @@ Resources:
 
   ExperianKBVOnlyOneTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${AWS::StackName}-${Environment}-ExperianKBVOnlyOneTaskCountAlarm
       AlarmDescription: !Sub Experian KBV ${Environment} frontend below desired ECS service tasks. ${SupportManualURL}
@@ -822,6 +882,7 @@ Resources:
 
   ExperianKBV5XXOnELB:
     Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${AWS::StackName}-${Environment}-ExperianKBV5XXOnELB
       AlarmDescription: !Sub Experian KBV ${Environment} frontend 5XX count. ${SupportManualURL}


### PR DESCRIPTION
## Proposed changes

We need to have a 5XX Alarm (P1) if more than 80% of your traffic is returning 5XX in 2 of 5 datapoints to ensure that the team is aware if there is an high volume of 5XX errors, please implement an alarm similar to the following that will raise a critical alert if the volume of 5XXs is likely to mean a significant loss of service that would manifest as a service outage.

### What changed

Added new Alarm definition for the above in Experian-cri

The invocation have been adjusted based on observed, traffic last [90days](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?dispatch.sample_ratio=1&display.page.search.mode=smart&workload_pool=standard_perf&q=search%20index%3D%22gds_di_production%22%20source%3D%22*kbv-cri-front-*%22%20sourcetype%3D%22aws%3Acloudwatchlogs%3Aapi-access-*%22%20di_account_name_enriched%3D%22di-ipv-cri-kbv-prod%22%20%0A%7C%20timechart%20span%3D1d%20count%20as%20requests&earliest=-90d%40d&latest=now&display.page.search.tab=visualizations&display.general.type=visualizations&sid=1734438917.66158) see below

![image](https://github.com/user-attachments/assets/789f24f4-001c-4892-a66a-a140994b7d6d)

```
index="gds_di_production" source="*kbv-cri-front-*" sourcetype="aws:cloudwatchlogs:api-access-*" di_account_name_enriched="di-ipv-cri-kbv-prod" 
| timechart span=1d count as requests
```

The minimum invocation is approximately 2700 invocation / day
Which is 2,700 ÷1,440 approximately 2 invocations / minute

The errorThreshold  invocations < 10 seems ideal for Experian KBV based on average volumes per minute

### Why did it change

Added DeployAlarmsInDevEnvironment and set to true, so as to observe alarm in dev, would set back to false

Added new Alarm definition for the above in Experian-kbv-cri

The invocation have been adjusted based on observed, traffic see above

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2872](https://govukverify.atlassian.net/browse/OJ-2872)



[OJ-2872]: https://govukverify.atlassian.net/browse/OJ-2872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ