### PR TITLE
OJ-2830: bump hmpo-components again

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "express-async-errors": "3.1.1",
     "express-session": "^1.18.0",
     "govuk-frontend": "4.9.0",
-    "hmpo-components": "7.0.0",
+    "hmpo-components": "7.1.0",
     "hmpo-config": "4.0.0",
     "hmpo-form-wizard": "13.0.2",
     "hmpo-i18n": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,10 +3422,10 @@ helmet@^8.0.0:
   resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.0.0.tgz#05370fb1953aa7b81bd0ddfa459221247be6ea5c"
   integrity sha512-VyusHLEIIO5mjQPUI1wpOAEu+wl6Q0998jzTxqUYGE45xCIcAxy3MsbEK/yyJUJ3ADeMoB6MornPH6GMWAf+Pw==
 
-hmpo-components@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/hmpo-components/-/hmpo-components-7.0.0.tgz#d60e5f6fa2387cdaf575359db7cab63b14d00ce6"
-  integrity sha512-ZuqzGGUfVKMhkaQLB8zwA0Ec3Uz6Ss6iX35BBUg7+vH+z0Z943riak9fIoTuIsXhY7Sx+ov0Upt3PG6tC3/8QA==
+hmpo-components@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/hmpo-components/-/hmpo-components-7.1.0.tgz#bae09ce82d3bb6a0a35d3f1d243f46dd7ae2ade0"
+  integrity sha512-gv/m2+tDfHU10xxnT9seoI2nVtJEgcMSFfl3zACdUY1rNV3SCUv426tvxuq0Z/7jAoHLfB8mvDcHaHpPEysVLw==
   dependencies:
     bytes "^3.1.2"
     deep-clone-merge "^1.5.5"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

bump hmpo-components again

### Why did it change

To fix build command

Before
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/dd949fed-770f-4ae4-9367-17ec7e2cc67a" />

After
<img width="1350" alt="Screenshot 2025-01-14 at 2 03 56 pm" src="https://github.com/user-attachments/assets/51c9f570-d3af-42ae-9128-f4d2cbf5ea96" />



### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2830](https://govukverify.atlassian.net/browse/OJ-2830)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-2830]: https://govukverify.atlassian.net/browse/OJ-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ