### PR TITLE
fix(dfc-758): add data attributes for navigation tracking

### DIFF
--- a/src/views/kbv/abandon.njk
+++ b/src/views/kbv/abandon.njk
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block submitButton %}
-  {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+  {{ hmpoSubmit(ctx, {id: "continue", attributes: {"data-nav": true, "data-link": "/undefined"}, text: translate("buttons.next")}) }}
   <script nonce="{{ cspNonce }}">
       var formSubmitted = false;
       submitSpinner()

--- a/src/views/kbv/check.njk
+++ b/src/views/kbv/check.njk
@@ -18,7 +18,7 @@ summaryText: translate("pages.check.details.title"),
 html: hmpoHtml(translate("pages.check.details.content"))
 }) }}
 
-{{ hmpoSubmit(ctx, {text: translate("buttons.next")}) }}
+{{ hmpoSubmit(ctx, {attributes: {"data-nav": true, "data-link": "/undefined"}, text: translate("buttons.next")}) }}
 
 {% endcall %}
 

--- a/src/views/kbv/question.njk
+++ b/src/views/kbv/question.njk
@@ -10,7 +10,7 @@
 
   {% call hmpoForm(ctx) %}
     {{ hmpoRadios(ctx, question) }}
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {id: "continue", attributes: {"data-nav": true, "data-link": "/undefined"}, text: translate("buttons.next")}) }}
     <script nonce="{{ cspNonce }}">
         var formSubmitted = false;
         submitSpinner()


### PR DESCRIPTION
## Proposed changes

### What changed

Adds the required data attributes for the GA4 navigation tracker to fire on page navigation. The `data-link` attribute is set to `/undefined` after discussion with the Analytics team due to the dynamic nature of this section of the journey.

### Why did it change

Without the added attributes, the current iteration of the navigation tracker will not fire

### Issue tracking

- [DFC-758](https://govukverify.atlassian.net/browse/DFC-758)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[DFC-758]: https://govukverify.atlassian.net/browse/DFC-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ