### PR TITLE
IPS-1333: Predictive scaling for ECS in forecast mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         exclude: package-lock.json
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
         exclude: .yarn
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.3
+    rev: v1.22.7
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -111,14 +111,14 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     },
     {
-      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": []
     },
     {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
       "pattern": []
     }
   ],
   "results": {},
-  "generated_at": "2023-11-28T15:51:15Z"
+  "generated_at": "2025-01-24T15:49:17Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -52,16 +52,9 @@ Parameters:
     Default: false
 
 Conditions:
-  IsNotDevelopment: !Or
-    - !Equals [!Ref Environment, build]
-    - !Equals [!Ref Environment, staging]
-    - !Equals [!Ref Environment, integration]
-    - !Equals [!Ref Environment, production]
+  IsNotDevelopment: !Not
+    - !Equals [!Ref Environment, dev]
   IsProduction: !Equals [!Ref Environment, production]
-
-  IsProductionOrBuild: !Or
-    - !Equals [!Ref Environment, production]
-    - !Equals [!Ref Environment, build]
 
   IsBuildOrDev: !Or
     - !Equals [!Ref Environment, build]
@@ -85,14 +78,24 @@ Mappings:
   EnvironmentConfiguration:
     dev:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 1
+      maxECSCount: 4
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 6
+      maxECSCount: 60
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 2
+      maxECSCount: 4
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 2
+      maxECSCount: 4
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+      minECSCount: 6
+      maxECSCount: 60
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
@@ -286,6 +289,11 @@ Resources:
 
   KBVFrontEcsService:
     Type: AWS::ECS::Service
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3056 #We want to remove load balancers if we are doing canary deployments
     Properties:
       Cluster: !Ref KBVFrontEcsCluster
       DeploymentConfiguration: !If
@@ -680,32 +688,24 @@ Resources:
   # Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.
 
   ECSAutoScalingTarget:
-    Condition: IsProductionOrBuild
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 60
-      MinCapacity: 6
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref KBVFrontEcsCluster
-          - !GetAtt KBVFrontEcsService.Name
+      MinCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
+      MaxCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, maxECSCount]
+      ResourceId: !Sub service/${KBVFrontEcsCluster}/${KBVFrontEcsService.Name}
       RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
 
   ECSAutoScalingPolicy:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: ECSAutoScalingPolicy
       PolicyType: TargetTrackingScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref KBVFrontEcsCluster
-          - !GetAtt KBVFrontEcsService.Name
+      ResourceId: !Sub service/${KBVFrontEcsCluster}/${KBVFrontEcsService.Name}
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
       TargetTrackingScalingPolicyConfiguration:
@@ -715,18 +715,31 @@ Resources:
         ScaleInCooldown: 420
         ScaleOutCooldown: 60
 
+  ECSPredictiveScalingPolicy:
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ECSPredictiveScalingPolicy
+      PolicyType: PredictiveScaling
+      ResourceId: !Sub service/${KBVFrontEcsCluster}/${KBVFrontEcsService.Name}
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      PredictiveScalingPolicyConfiguration:
+        MaxCapacityBreachBehavior: HonorMaxCapacity
+        MetricSpecifications:
+          - PredefinedMetricPairSpecification:
+              PredefinedMetricType: ECSServiceCPUUtilization
+            TargetValue: 60
+        Mode: ForecastOnly
+        SchedulingBufferTime: 600
+
   StepScaleInPolicy:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: StepScalingInPolicy
       PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref KBVFrontEcsCluster
-          - !GetAtt KBVFrontEcsService.Name
+      ResourceId: !Sub service/${KBVFrontEcsCluster}/${KBVFrontEcsService.Name}
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
@@ -740,17 +753,12 @@ Resources:
             ScalingAdjustment: -50
 
   StepScaleOutPolicy:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: StepScalingOutPolicy
       PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref KBVFrontEcsCluster
-          - !GetAtt KBVFrontEcsService.Name
+      ResourceId: !Sub service/${KBVFrontEcsCluster}/${KBVFrontEcsService.Name}
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
@@ -770,7 +778,6 @@ Resources:
             ScalingAdjustment: 500
 
   ExperianKBVStepScaleOutAlarm:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -795,7 +802,6 @@ Resources:
       Threshold: "60"
 
   ExperianKBVStepScaleInAlarm:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
### What changed

- Update pre-commit config
- Added capacity mapping for ECS task counts 
- Removed condition on creating auto scaling policy so it applies to all envs
- This adds a new Predictive scaling policy which will scale the number of instances based on some AWS created  algorithm using the previous traffic patterns as input. See this for more information:
https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html
- The policy is in `Forecast Mode` only so we can understand its behaviour. The predictive scaling policy will not take any action, see below in dev:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/2ab90b4b-49b1-416d-8e57-064f78092bb5" />

### Why did it change

- Cost saving
- To be more Environmentally friendly
- Reliability for users

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1284
