### PR TITLE
OJ-3012: Fix - remove back button from question pages

### DIFF
--- a/src/views/kbv/question.njk
+++ b/src/views/kbv/question.njk
@@ -6,6 +6,8 @@
 
 {% set hmpoTitle = question.label %}
 
+{% set backLink = null %}
+
 {% block mainContent %}
 
   {% call hmpoForm(ctx) %}


### PR DESCRIPTION

## Proposed changes

### What changed

- Removed back link from questions screen

https://github.com/user-attachments/assets/68105078-6b79-4161-ad95-6ffc2ec2273f



### Why did it change

The Back link should be hidden from all question screens in Experian KBV CRI. To prevent users returning to the `/abandon` screen after returning to the question screen

### Issue tracking

- [OJ-3012](https://govukverify.atlassian.net/browse/OJ-3012)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3012]: https://govukverify.atlassian.net/browse/OJ-3012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ