### PR TITLE
OJ-2948: Update kbv abandon screen

### DIFF
--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -1,7 +1,7 @@
 module.exports = {
   abandonRadio: {
     type: "radios",
-    items: ["continue", "stop"],
+    items: ["stop", "continue"],
     validate: ["required"],
   },
 };

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -50,12 +50,12 @@ abandonRadio:
     required: "Mae'n rhaid i chi ddewis opsiwn i barhau"
   items:
     continue:
-      label: "Ydw - profi fy hunaniaeth mewn ffordd arall"
+      label: "Na - parhau i ateb cwestiynau diogelwch"
       value: "parhau"
       hint: ""
       reveal: ""
     stop:
-      label: "Na - parhau i ateb cwestiynau diogelwch"
+      label: "Ydw - profi fy hunaniaeth mewn ffordd arall"
       value: "stop"
       hint: ""
       reveal: ""

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -42,20 +42,20 @@ preConfiguredValues:
     decerqueiraKenneth:
       label: "Decerqueria, Kenneth - Dilysu lefel 1"
 abandonRadio:
-  label: "Beth hoffech chi ei wneud?"
-  legend: "Beth hoffech chi ei wneud?"
+  label: ""
+  legend: ""
   hint: ""
   content: ""
   validation:
     required: "Mae'n rhaid i chi ddewis opsiwn i barhau"
   items:
     continue:
-      label: "Parhewch i ateb y cwestiynau diogelwch"
+      label: "Ydw - profi fy hunaniaeth mewn ffordd arall"
       value: "parhau"
       hint: ""
       reveal: ""
     stop:
-      label: "Stopiwch ateb y cwestiynau diogelwch a phrofi pwy ydych chi mewn ffordd arall"
+      label: "Na - parhau i ateb cwestiynau diogelwch"
       value: "stop"
       hint: ""
       reveal: ""

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -18,8 +18,7 @@ error:
 simplifiedQuestion:
   abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>Ni allaf ateb y cwestiwn hwn</a>"
 abandonCheck:
-  title: "Rhaid i chi ateb pob cwestiwn diogelwch i brofi pwy ydych chi"
-  h1: "Rhaid i chi ateb pob cwestiwn diogelwch i brofi pwy ydych chi"
-  content:
-    - "Ni allwch hepgor unrhyw gwestiynau."
+  title: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"
+  h1: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"
+  warning: "Ni allwch ddychwelyd i'r sgrin hon os ydych chi'n chwilio am ffordd arall o brofi eich hunaniaeth."
   contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)</a></p>"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -51,20 +51,20 @@ preConfiguredValues:
       label: Decerqueria, Kenneth - Authenticated level 1
 
 abandonRadio:
-  label: What would you like to do?
-  legend: What would you like to do?
+  label: ""
+  legend: ""
   hint: ""
   content: ""
   validation:
     required: You must choose an option to continue
   items:
     continue:
-      label: Continue answering the security questions
+      label: No - continue answering security questions
       value: continue
       reveal: ""
       hint: ""
     stop:
-      label: Stop answering the security questions and prove your identity another way
+      label: Yes - prove my identity another way
       value: stop
       hint: ""
       reveal: ""

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -21,8 +21,7 @@ simplifiedQuestion:
   abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>I cannot answer this question</a>"
 
 abandonCheck:
-  title: You must answer all security questions to prove your identity
-  h1: You must answer all security questions to prove your identity
-  content:
-    - You cannot skip any questions.
+  title: Are you sure you want to prove your identity another way?
+  h1: Are you sure you want to prove your identity another way?
+  warning: You cannot return to this screen if you choose another way to prove your identity.
   contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Contact the GOV.UK One Login team (opens in a new tab)</a></p>"

--- a/src/views/kbv/abandon.njk
+++ b/src/views/kbv/abandon.njk
@@ -46,10 +46,9 @@
           })
         }
         </script>
+  {% endcall %}
 
   {{ hmpoHtml(translate("pages.abandonCheck.contact")) }}
-
-  {% endcall %}
 
   {{ ga4OnPageLoad({
     nonce: cspNonce,

--- a/src/views/kbv/abandon.njk
+++ b/src/views/kbv/abandon.njk
@@ -1,12 +1,55 @@
 {% extends "base-form.njk" %}
 {% from "components/onPageLoad/macro.njk" import ga4OnPageLoad %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "hmpo-radios/macro.njk" import hmpoRadios %}
+{% from "hmpo-form/macro.njk" import hmpoForm %}
 {% set hmpoPageKey = "abandonCheck" %}
 {% set isPageHeading = true %}
 
 {% block mainContent %}
-  {{ super() }}
+
+<h1 id="header" class="govuk-heading-l">{{translate("pages.abandonCheck.title")}}</h1>
+
+ {% call hmpoForm(ctx) %}
+      {{ hmpoRadios(ctx, {
+            id: "abandonRadio",
+            namePrefix: "abandonRadio",
+            fieldset: {
+                legend: {
+                    isPageHeading: true,
+                    classes: "govuk-fieldset__legend--l"
+                }
+            }
+        }) }}
+
+  {{ govukWarningText({text: translate("abandonCheck.warning")}) }}
+
+  {{ hmpoSubmit(ctx, {id: "continue", attributes: {"data-nav": true, "data-link": "/undefined"}, text: translate("buttons.next")}) }}
+  <script nonce="{{ cspNonce }}">
+        var formSubmitted = false;
+        submitSpinner()
+        function delayDisableButton(button) {
+          button.className += ' button--spinner'
+          setTimeout(function() {
+                button.setAttribute('disabled', true)
+            }, 200);
+        }
+        function submitSpinner() {
+          var select = document.getElementById('continue')
+          select.addEventListener('click', function (event) {
+          if (formSubmitted) {
+                event.preventDefault()
+              } else {
+                formSubmitted = true;
+                delayDisableButton(event.target);
+            }
+          })
+        }
+        </script>
 
   {{ hmpoHtml(translate("pages.abandonCheck.contact")) }}
+
+  {% endcall %}
 
   {{ ga4OnPageLoad({
     nonce: cspNonce,
@@ -19,29 +62,4 @@
     dynamic: false
   }) }}
 
-{% endblock %}
-
-{% block submitButton %}
-  {{ hmpoSubmit(ctx, {id: "continue", attributes: {"data-nav": true, "data-link": "/undefined"}, text: translate("buttons.next")}) }}
-  <script nonce="{{ cspNonce }}">
-      var formSubmitted = false;
-      submitSpinner()
-      function delayDisableButton(button) {
-        button.className += ' button--spinner'
-        setTimeout(function() {
-              button.setAttribute('disabled', true)
-          }, 200);
-      }
-      function submitSpinner() {
-        var select = document.getElementById('continue')
-        select.addEventListener('click', function (event) {
-        if (formSubmitted) {
-              event.preventDefault()
-            } else {
-              formSubmitted = true;
-              delayDisableButton(event.target);
-          }
-        })
-      }
-      </script>
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

New abandon screen changes:

<img width="660" alt="image" src="https://github.com/user-attachments/assets/55f3ad53-faca-4f89-bfd0-6c7eca442448" />

Welsh abandon screen: 
<img width="839" alt="image" src="https://github.com/user-attachments/assets/f6fe4d03-e81c-4590-92b4-a40a5fa14f8c" />

verifying continue button spinner and is disabled when clicked:

https://github.com/user-attachments/assets/4ee07e8a-e39b-46bd-ba32-fecbbeb8b28f



### Why did it change
Based on the changes to improve KBV abandon screen

### Issue tracking

- [OJ-2948](https://govukverify.atlassian.net/browse/OJ-2948)

## Checklists

- [x] No environment variables or secrets were added or changed



[OJ-2948]: https://govukverify.atlassian.net/browse/OJ-2948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ