### PR TITLE
OJ-2871: feat - Add SigTERM graceful shutdown fix, and the server kee…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -182,3 +182,30 @@ router.use("^/$", (req, res) => {
 });
 
 router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);
+
+/* Server configuration */
+const server = app.listen(PORT);
+
+// AWS recommends the keep-alive duration of the target is longer than the idle timeout value of the load balancer (default 60s)
+// to prevent possible 502 errors where the target connection has already been closed
+// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html#http-502-issues
+server.keepAliveTimeout = 65000;
+
+// Handles graceful shutdown of the NODE service, so that if the container is killed by a SIGTERM, it finishes processing existing connections before the server shuts down.
+process.on("SIGTERM", () => {
+  // eslint-disable-next-line no-console
+  console.log("SIGTERM signal received: closing HTTP server");
+  server.close((err) => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `Error while calling server.close() occurred: ${err.message}`
+      );
+    } else {
+      // eslint-disable-next-line no-console
+      console.log("HTTP server closed");
+    }
+
+    process.exit(0);
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -68,7 +68,7 @@ const {
 
 const { app, router } = setup({
   config: { APP_ROOT: __dirname },
-  port: PORT,
+  port: false, /// Disabling the bootstrap starting the server.
   logs: loggerConfig,
   session: sessionConfig,
   helmet: helmetConfig,


### PR DESCRIPTION
## Proposed changes

### What changed

- Implemented SIGTERM within in the `app.js` where it gets initialised.
- Increase KeepAliveTimeout to greater than the upstream ALB's idle_timeout.

<img width="424" alt="image" src="https://github.com/user-attachments/assets/2e418c12-751b-4250-8f3a-ab613deff64a" />


### Why did it change

As part of the FE health check, to ensure that existing connections are served, before the service shuts down and to reduce 502 errors.

### Issue tracking

- [OJ-2871](https://govukverify.atlassian.net/browse/OJ-2871)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2871]: https://govukverify.atlassian.net/browse/OJ-2871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ