### PR TITLE
OJ-2947: Updates to the /kbv/question Screen

### DIFF
--- a/src/app/kbv/controllers/question.test.js
+++ b/src/app/kbv/controllers/question.test.js
@@ -72,7 +72,7 @@ describe("Question controller", () => {
       expect(req.form.options.fields.Q1).to.deep.equal({
         type: "radios",
         validate: ["required"],
-        items: ["V1", "V2", "V3"],
+        items: ["V1", "V2", "V3", { divider: true, key: "answers.divider" }],
       });
     });
 

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -4,3 +4,7 @@ $govuk-assets-path: "/public/";
 @import "../../../node_modules/hmpo-components/all";
 @import "../../../node_modules/@govuk-one-login/frontend-language-toggle/stylesheet/styles";
 @import "./components/button-spinner";
+
+.govuk-hint p {
+  color: #505a5f !important;
+}

--- a/src/lib/answer-config.js
+++ b/src/lib/answer-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   noneOfTheAbove: {
     key: "answers.noneOfTheAbove",
-    regexp: new RegExp("^NONE OF THE ABOVE / DOES NOT APPLY$", "g"),
+    regexp: /^None of the above \/ does not apply$/,
   },
   upToMonths: {
     key: "answers.upToMonths",

--- a/src/lib/dynamic/question.js
+++ b/src/lib/dynamic/question.js
@@ -16,7 +16,9 @@ function answerListToTranslatedItems(answerList) {
 }
 
 function answerListToFieldItems(answerList) {
-  return answerList.map((answer) => answer);
+  let fieldItems = answerList.map((answer) => answer);
+  fieldItems.splice(4, 0, { divider: true, key: "answers.divider" });
+  return fieldItems;
 }
 
 function questionToTranslations(question) {

--- a/src/lib/dynamic/question.test.js
+++ b/src/lib/dynamic/question.test.js
@@ -91,7 +91,7 @@ describe("question", () => {
       expect(config).to.deep.equal({
         type: "radios",
         validate: ["required"],
-        items: ["ABC", "DEF"],
+        items: ["ABC", "DEF", { divider: true, key: "answers.divider" }],
       });
     });
   });
@@ -102,7 +102,11 @@ describe("question", () => {
         question.answerFormat.answerList
       );
 
-      expect(config).to.deep.equal(["ABC", "DEF"]);
+      expect(config).to.deep.equal([
+        "ABC",
+        "DEF",
+        { divider: true, key: "answers.divider" },
+      ]);
     });
   });
 });

--- a/src/lib/dynamic/question.test.js
+++ b/src/lib/dynamic/question.test.js
@@ -9,7 +9,7 @@ describe("question", () => {
       text: "text",
       toolTip: "tooltip",
       answerFormat: {
-        answerList: ["ABC", "DEF"],
+        answerList: ["ABC", "DEF", "GHI", "JKL", "none of the above"],
       },
     };
   });
@@ -52,7 +52,13 @@ describe("question", () => {
         },
       } = dynamicQuestion.questionToTranslations(question);
 
-      expect(items).to.have.all.keys("ABC", "DEF");
+      expect(items).to.have.all.keys(
+        "ABC",
+        "DEF",
+        "GHI",
+        "JKL",
+        "none of the above"
+      );
     });
   });
 
@@ -66,7 +72,7 @@ describe("question", () => {
     });
 
     it("should contain all answers", () => {
-      expect(Object.keys(items).length).to.equal(2);
+      expect(Object.keys(items).length).to.equal(5);
     });
 
     it("should use answer for value", () => {
@@ -91,7 +97,22 @@ describe("question", () => {
       expect(config).to.deep.equal({
         type: "radios",
         validate: ["required"],
-        items: ["ABC", "DEF", { divider: true, key: "answers.divider" }],
+        items: [
+          "ABC",
+          "DEF",
+          "GHI",
+          "JKL",
+          { divider: true, key: "answers.divider" },
+          "none of the above",
+        ],
+      });
+    });
+
+    it("should verify the divider is at the 5th radio element", () => {
+      const config = dynamicQuestion.questionToFieldsConfig(question);
+      expect(config.items[4]).to.deep.equal({
+        divider: true,
+        key: "answers.divider",
       });
     });
   });
@@ -105,7 +126,10 @@ describe("question", () => {
       expect(config).to.deep.equal([
         "ABC",
         "DEF",
+        "GHI",
+        "JKL",
         { divider: true, key: "answers.divider" },
+        "none of the above",
       ]);
     });
   });

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -69,8 +69,9 @@ error:
 validation:
   required: "Mae angen i chi ateb y cwestiwn"
 answers:
-  noneOfTheAbove: "Dim o'r uchod / Nid yw'n berthnasol"
+  noneOfTheAbove: "Dim o'r uchod neu nid yw'r cwestiwn hwn yn berthnasol i mi"
   upToMonths: "Hyd at {{ months }} mis"
   overUpToMonths: "Dros {{ months_low }} mis hyd at {{ months_high }} mis"
   upToAmount: "Hyd at £{{ amount }}"
   overUpToAmount: "Dros £{{ amount_low }} hyd at £{{ amount_high }}"
+  divider: "neu"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -16,8 +16,8 @@ error:
   unrecoverable:
     title: "Mae'n ddrwg gennym, mae problem"
 simplifiedQuestion:
-  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>Nid wyf yn gwybod yr ateb i'r cwestiwn hwn</a>"
-  abandonBody: "Os na allwch ateb cwestiwn, bydd angen i chi brofi eich hunaniaeth mewn ffordd arall.<br/>Ni allwch hepgor unrhyw gwestiynau."
+  abandon: "Nid wyf yn gwybod yr ateb i'r cwestiwn hwn"
+  abandonBody: "Os na allwch ateb cwestiwn, bydd angen i chi <a href='/kbv/abandon' class='govuk-link' data-id='abandon'>brofi eich hunaniaeth mewn ffordd arall</a>.<br><br>Ni allwch hepgor unrhyw gwestiynau."
 abandonCheck:
   title: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"
   h1: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -16,7 +16,8 @@ error:
   unrecoverable:
     title: "Mae'n ddrwg gennym, mae problem"
 simplifiedQuestion:
-  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>Ni allaf ateb y cwestiwn hwn</a>"
+  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>Nid wyf yn gwybod yr ateb i'r cwestiwn hwn</a>"
+  abandonBody: "Os na allwch ateb cwestiwn, bydd angen i chi brofi eich hunaniaeth mewn ffordd arall.<br/>Ni allwch hepgor unrhyw gwestiynau."
 abandonCheck:
   title: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"
   h1: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -69,8 +69,9 @@ error:
 validation:
   required: "You need to answer the question"
 answers:
-  noneOfTheAbove: "None of the above / does not apply"
+  noneOfTheAbove: "None of the above or this question does not apply to me"
   upToMonths: "UP TO {{ months }} months"
   overUpToMonths: "OVER {{ months_low }} months UP TO {{ months_high }} months"
   upToAmount: "UP TO £ {{ amount }} "
   overUpToAmount: "OVER £{{ amount_low }} UP TO £{{ amount_high }}"
+  divider: "or"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -18,8 +18,8 @@ error:
     title: Sorry, there is a problem with the service
 
 simplifiedQuestion:
-  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>I do not know the answer to this question</a>"
-  abandonBody: "If you cannot answer a question, you will need to prove your identity another way.<br/>You cannot skip any questions."
+  abandon: "I do not know the answer to this question"
+  abandonBody: "If you cannot answer a question, you will need to <a href='/kbv/abandon' class='govuk-link' data-id='abandon'>prove your identity another way</a>.<br><br>You cannot skip any questions."
 
 abandonCheck:
   title: Are you sure you want to prove your identity another way?

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -18,7 +18,8 @@ error:
     title: Sorry, there is a problem with the service
 
 simplifiedQuestion:
-  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>I cannot answer this question</a>"
+  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>I do not know the answer to this question</a>"
+  abandonBody: "If you cannot answer a question, you will need to prove your identity another way.<br/>You cannot skip any questions."
 
 abandonCheck:
   title: Are you sure you want to prove your identity another way?

--- a/src/presenters/answer-to-radio-item.test.js
+++ b/src/presenters/answer-to-radio-item.test.js
@@ -9,9 +9,9 @@ describe("answer-to-radio-item", () => {
     translate = sinon.stub().returnsArg(0);
   });
 
-  context("'NONE OF THE ABOVE / DOES NOT APPLY'", () => {
+  context("'None of the above / does not apply'", () => {
     beforeEach(() => {
-      answer = "NONE OF THE ABOVE / DOES NOT APPLY";
+      answer = "None of the above / does not apply";
 
       result = presenters.answerToRadioItem(answer, translate);
     });

--- a/src/presenters/question-to-radios.js
+++ b/src/presenters/question-to-radios.js
@@ -16,6 +16,7 @@ module.exports = function (question, translate) {
     },
     hint: {
       html: questionToHint(question, translate),
+      classes: "govuk-hint p",
     },
     items: question?.answerFormat?.answerList?.map((answer) =>
       answerToRadioItem(answer, translate)

--- a/src/presenters/question-to-radios.test.js
+++ b/src/presenters/question-to-radios.test.js
@@ -14,7 +14,7 @@ describe("question-to-radios", () => {
         "05 / 1999",
         "12 / 2020",
         "07 / 2012",
-        "NONE OF THE ABOVE / DOES NOT APPLY",
+        "None of the above / does not apply",
       ],
     },
   };
@@ -59,7 +59,7 @@ describe("question-to-radios", () => {
   });
 
   it("should use answers for items", () => {
-    translate.returns("NONE OF THE ABOVE / DOES NOT APPLY");
+    translate.returns("None of the above / does not apply");
 
     config = presenters.questionToRadios(question, translate);
 
@@ -109,9 +109,9 @@ describe("question-to-radios", () => {
         },
       },
       {
-        id: "NONE OF THE ABOVE / DOES NOT APPLY",
-        value: "NONE OF THE ABOVE / DOES NOT APPLY",
-        text: "NONE OF THE ABOVE / DOES NOT APPLY",
+        id: "None of the above / does not apply",
+        value: "None of the above / does not apply",
+        text: "None of the above / does not apply",
         hint: {
           html: " ",
         },

--- a/src/views/kbv/question.njk
+++ b/src/views/kbv/question.njk
@@ -1,5 +1,6 @@
 {% extends "base-form.njk" %}
 {% from "hmpo-radios/macro.njk" import hmpoRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "components/onPageLoad/macro.njk" import ga4OnPageLoad %}
 
 {% set gtmJourney = "kbv - middle" %}
@@ -12,6 +13,12 @@
 
   {% call hmpoForm(ctx) %}
     {{ hmpoRadios(ctx, question) }}
+
+    {{ govukDetails({
+      summaryText: translate("pages.simplifiedQuestion.abandon"),
+      text: translate("pages.simplifiedQuestion.abandonBody") | safe
+    }) }}
+
     {{ hmpoSubmit(ctx, {id: "continue", attributes: {"data-nav": true, "data-link": "/undefined"}, text: translate("buttons.next")}) }}
     <script nonce="{{ cspNonce }}">
         var formSubmitted = false;
@@ -35,8 +42,6 @@
         }
         </script>
   {% endcall %}
-
-  {{ hmpoHtml(translate("pages.simplifiedQuestion.abandon")) }}
 
 {{ ga4OnPageLoad({
   nonce: cspNonce,

--- a/test/browser/pages/question.js
+++ b/test/browser/pages/question.js
@@ -52,6 +52,7 @@ module.exports = class PlaywrightDevPage {
   }
 
   async abandon() {
+    this.page.locator(".govuk-details__summary-text").click();
     await this.page.click('[data-id="abandon"]');
   }
 };

--- a/test/browser/pages/question.js
+++ b/test/browser/pages/question.js
@@ -51,6 +51,10 @@ module.exports = class PlaywrightDevPage {
       .check();
   }
 
+  async orDivider() {
+    return this.page.textContent(".govuk-radios__divider");
+  }
+
   async abandon() {
     this.page.locator(".govuk-details__summary-text").click();
     await this.page.click('[data-id="abandon"]');

--- a/test/browser/step_definitions/kbv.js
+++ b/test/browser/step_definitions/kbv.js
@@ -27,6 +27,9 @@ Then("they should see the first question", async function () {
 
   this.questionTitle = await questionPage.getPageTitle();
   expect(this.questionTitle).not.to.be.empty;
+
+  const divider = await questionPage.orDivider();
+  expect(divider).not.to.be.empty;
 });
 
 When(/^they answer the first question$/, async function () {
@@ -53,6 +56,9 @@ When(/^they answer the first question incorrectly$/, async function () {
 Then("they should see the second question", async function () {
   const questionPage = new QuestionPage(this.page);
   expect(questionPage.isCurrentPage()).to.be.true;
+
+  const divider = await questionPage.orDivider();
+  expect(divider).not.to.be.empty;
 });
 
 Then(

--- a/test/mocks/mappings/abandon.json
+++ b/test/mocks/mappings/abandon.json
@@ -71,7 +71,7 @@
               "05 / 1999",
               "12 / 2020",
               "07 / 2012",
-              "NONE OF THE ABOVE / DOES NOT APPLY"
+              "None of the above / does not apply"
             ]
           }
         }

--- a/test/mocks/mappings/answer-error.json
+++ b/test/mocks/mappings/answer-error.json
@@ -71,7 +71,7 @@
               "05 / 1999",
               "12 / 2020",
               "07 / 2012",
-              "NONE OF THE ABOVE / DOES NOT APPLY"
+              "None of the above / does not apply"
             ]
           }
         }

--- a/test/mocks/mappings/questions.json
+++ b/test/mocks/mappings/questions.json
@@ -74,7 +74,7 @@
               "OVER £9,250 UP TO £9,500",
               "OVER £9,500 UP TO £9,750",
               "OVER £9,750 UP TO £10,000",
-              "NONE OF THE ABOVE / DOES NOT APPLY"
+              "None of the above / does not apply"
             ]
           }
         }
@@ -147,7 +147,7 @@
               "05 / 1999",
               "12 / 2020",
               "07 / 2012",
-              "NONE OF THE ABOVE / DOES NOT APPLY"
+              "None of the above / does not apply"
             ]
           }
         }


### PR DESCRIPTION
## Proposed changes

### What changed

- Added a new `govUkDetails` section to add text with the abandon link
- Added `or` in the second to last position of the radio button
- Updated content based on UCD changes
- Changed the last radio button "NONE OF THE ABOVE" string to use the content (once third party PR is merged)
- Change colour of hint text from black to gds grey

https://github.com/user-attachments/assets/89a22606-f3e7-48de-8707-a96fab751bc1



**Welsh translations**
<img width="818" alt="Screenshot 2025-02-13 at 12 14 29" src="https://github.com/user-attachments/assets/88fbf015-875f-4e0f-9122-cb26004728a7" />




### Why did it change
To have a clear and user-friendly interface to answer security questions related to my identity, so that I can understand the question format and select an appropriate response effortlessly.

This has been reviewed by UCD

### Issue tracking

- [OJ-2947](https://govukverify.atlassian.net/browse/OJ-2947)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2947]: https://govukverify.atlassian.net/browse/OJ-2947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ