### PR TITLE
Updating SonarCube GH Action to avoid deprecation

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@d201191485b645ec856a34e5ca48636cf97b2574
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@5480cced560e896dea12c47ea33e548a4d093e65
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed changes
Bumped the GH Action to use the new SonarCloud GH Action

### What changed
version pin

### Why did it change
Upstream action deprecated

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1428