### PR TITLE
OJ-3050: fix - include title within the legend

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -22,4 +22,4 @@ abandonCheck:
   title: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"
   h1: "Ydych chi'n siŵr eich bod chi eisiau profi eich hunaniaeth mewn ffordd arall?"
   warning: "Ni allwch ddychwelyd i'r sgrin hon os ydych chi'n chwilio am ffordd arall o brofi eich hunaniaeth."
-  contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)</a></p>"
+  contact: "<a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)</a>"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -25,4 +25,4 @@ abandonCheck:
   title: Are you sure you want to prove your identity another way?
   h1: Are you sure you want to prove your identity another way?
   warning: You cannot return to this screen if you choose another way to prove your identity.
-  contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Contact the GOV.UK One Login team (opens in a new tab)</a></p>"
+  contact: "<a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Contact the GOV.UK One Login team (opens in a new tab)</a>"

--- a/src/views/kbv/abandon.njk
+++ b/src/views/kbv/abandon.njk
@@ -8,14 +8,13 @@
 
 {% block mainContent %}
 
-<h1 id="header" class="govuk-heading-l">{{translate("pages.abandonCheck.title")}}</h1>
-
  {% call hmpoForm(ctx) %}
       {{ hmpoRadios(ctx, {
             id: "abandonRadio",
             namePrefix: "abandonRadio",
             fieldset: {
                 legend: {
+                    html:translate("pages.abandonCheck.title"),
                     isPageHeading: true,
                     classes: "govuk-fieldset__legend--l"
                 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Update html tags to use be the same as [here](https://design-system.service.gov.uk/components/radios/)
- Updated h1 to be within the form legend
<img width="1372" alt="Screenshot 2025-02-19 at 16 46 25" src="https://github.com/user-attachments/assets/787216a4-827f-4e0a-85ff-e4ade748f580" />



- Removed blank `<p>` tags by updating the string
<img width="1376" alt="Screenshot 2025-02-19 at 16 06 02" src="https://github.com/user-attachments/assets/43cdf4ba-2a92-4be9-8a1c-190e18ab55ea" />



### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

- [OJ-3050](https://govukverify.atlassian.net/browse/OJ-3050)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3050]: https://govukverify.atlassian.net/browse/OJ-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ