### PR TITLE
OJ-3071: fix - make noneOfTheAbove regex case insensitive

### DIFF
--- a/src/lib/answer-config.js
+++ b/src/lib/answer-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   noneOfTheAbove: {
     key: "answers.noneOfTheAbove",
-    regexp: /^None of the above \/ does not apply$/,
+    regexp: /^None of the above \/ does not apply$/i,
   },
   upToMonths: {
     key: "answers.upToMonths",

--- a/src/presenters/answer-to-radio-item.test.js
+++ b/src/presenters/answer-to-radio-item.test.js
@@ -38,6 +38,25 @@ describe("answer-to-radio-item", () => {
     });
   });
 
+  context("'NONE OF THE ABOVE / DOES NOT APPLY'", () => {
+    beforeEach(() => {
+      answer = "NONE OF THE ABOVE / DOES NOT APPLY";
+
+      result = presenters.answerToRadioItem(answer, translate);
+    });
+
+    it("should return radio item", () => {
+      expect(result.text).to.equal("answers.noneOfTheAbove");
+    });
+
+    it("should transform with extracted values", () => {
+      expect(translate).to.have.been.calledWithExactly(
+        "answers.noneOfTheAbove",
+        {}
+      );
+    });
+  });
+
   context("'OVER £9,500 UP TO £10,000'", () => {
     beforeEach(() => {
       answer = "OVER £9,500 UP TO £10,000";

--- a/src/presenters/question-to-radios.test.js
+++ b/src/presenters/question-to-radios.test.js
@@ -59,10 +59,13 @@ describe("question-to-radios", () => {
   });
 
   it("should use answers for items", () => {
-    translate.returns("None of the above / does not apply");
+    translate.returns(
+      "None of the above or this question does not apply to me"
+    );
 
     config = presenters.questionToRadios(question, translate);
 
+    expect(translate).to.have.been.calledWith("answers.noneOfTheAbove");
     expect(config.items).to.deep.equal([
       {
         id: "01 / 2022",
@@ -111,7 +114,7 @@ describe("question-to-radios", () => {
       {
         id: "None of the above / does not apply",
         value: "None of the above / does not apply",
-        text: "None of the above / does not apply",
+        text: "None of the above or this question does not apply to me",
         hint: {
           html: " ",
         },
@@ -120,5 +123,20 @@ describe("question-to-radios", () => {
         },
       },
     ]);
+  });
+
+  it("should accept case insensitive noneOfTheAbove radio", () => {
+    translate.returns(
+      "None of the above or this question does not apply to me"
+    );
+
+    question.answerFormat.answerList[4] = "NONE OF THE ABOVE / DOES NOT APPLY";
+
+    config = presenters.questionToRadios(question, translate);
+
+    expect(translate).to.have.been.calledWith("answers.noneOfTheAbove");
+    expect(config.items[4].text).to.equal(
+      "None of the above or this question does not apply to me"
+    );
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

- Added the `i` to the regex to allow case insensitive for noneOfTheAbove radio button

Still renders the string correctly locally:

<img width="1027" alt="Screenshot 2025-02-26 at 10 37 59" src="https://github.com/user-attachments/assets/264f9615-6c5f-43d8-bb1a-c74e7669b621" />


### Why did it change

- UAT was not rendering the correct string as the stubs were using `None of the above / does not apply` and UAT is using `NONE OF THE ABOVE / DOES NOT APPLY`

### Issue tracking

- [OJ-3071](https://govukverify.atlassian.net/browse/OJ-3071)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3071]: https://govukverify.atlassian.net/browse/OJ-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ