### PR TITLE
OJ-2697: Move dependencies required for building out of dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,9 @@
         "hmpo-i18n": "7.0.0",
         "hmpo-logger": "8.0.0",
         "nunjucks": "3.2.4",
-        "overload-protection": "1.2.3"
+        "overload-protection": "1.2.3",
+        "sass": "^1.77.6",
+        "uglify-js": "3.17.4"
       },
       "devDependencies": {
         "@cucumber/cucumber": "11.0.1",
@@ -50,10 +52,8 @@
         "playwright": "1.27.1",
         "prettier": "3.2.4",
         "proxyquire": "2.1.3",
-        "sass": "1.77.6",
         "sinon": "15.0.3",
         "sinon-chai": "3.7.0",
-        "uglify-js": "3.17.4",
         "wait-on": "7.2.0",
         "wiremock": "3.8.0"
       }
@@ -5941,7 +5941,6 @@
     },
     "node_modules/immutable": {
       "version": "4.3.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -9126,8 +9125,8 @@
     },
     "node_modules/sass": {
       "version": "1.77.6",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -9441,7 +9440,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10041,7 +10039,6 @@
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "uglifyjs": "bin/uglifyjs"

--- a/package.json
+++ b/package.json
@@ -47,10 +47,8 @@
     "playwright": "1.27.1",
     "prettier": "3.2.4",
     "proxyquire": "2.1.3",
-    "sass": "1.77.6",
     "sinon": "15.0.3",
     "sinon-chai": "3.7.0",
-    "uglify-js": "3.17.4",
     "wait-on": "7.2.0",
     "wiremock": "3.8.0"
   },
@@ -76,7 +74,9 @@
     "hmpo-i18n": "7.0.0",
     "hmpo-logger": "8.0.0",
     "nunjucks": "3.2.4",
-    "overload-protection": "1.2.3"
+    "overload-protection": "1.2.3",
+    "sass": "^1.77.6",
+    "uglify-js": "3.17.4"
   },
   "resolutions": {
     "strip-ansi": "^6.0.1",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Move dependencies required for building out of dev

### Why did it change

`npm run build` was failing after running `npm ci --production`

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2697](https://govukverify.atlassian.net/browse/OJ-2697)


[OJ-2697]: https://govukverify.atlassian.net/browse/OJ-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ