### PR TITLE
OJ-2697: Change production flag to omit-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY /src ./src
 
-RUN npm ci --production && npm run build && npm prune
+RUN npm ci --omit=dev && npm run build && npm prune
 
 FROM node:22.4.1-alpine3.19@${NODE_SHA} AS final
 RUN apk --no-cache upgrade && apk add --no-cache tini curl


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Change production flag to omit-dev

### Why did it change

Fixes warning `npm WARN config production Use --omit=dev instead.` which seemed to be breaking the docker builds

### Screenshots 
Before 

![image](https://github.com/user-attachments/assets/52c5d1d7-6091-484b-ae33-26df94e576ec)


After
![image](https://github.com/user-attachments/assets/2f8f3640-c640-496a-a747-a48e9c3ff947)


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2697](https://govukverify.atlassian.net/browse/OJ-2697)


[OJ-2697]: https://govukverify.atlassian.net/browse/OJ-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ