### PR TITLE
OJ-3322: chore - bump frontend-ui dependency for FEC fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
-        "@govuk-one-login/frontend-ui": "1.3.9",
+        "@govuk-one-login/frontend-ui": "1.3.12",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "axios": "1.11.0",
         "cfenv": "1.2.4",
@@ -1395,6 +1395,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-11.1.0.tgz",
       "integrity": "sha512-mZFl69j8MkxlwOmwG4oCZ9dB2N3WOXCd7VgFTabp27z9aa9ITDAqs2a7q0d1bDSdPCv/ef0A8YV5nIz41cN7kg==",
+      "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "^1.2.0",
         "async": "^3.2.6",
@@ -1499,9 +1500,10 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-ui": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.9.tgz",
-      "integrity": "sha512-PYrSRlqCauBAaObzeWchGT90B61pzt9Abjkx2tvdxZqzDBIfV1OPzHYS4Scd45ilVkY4O4CafRVqEPTJl0XCtw==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.12.tgz",
+      "integrity": "sha512-EKf43hi61A5IhIlaFRO2gPlOTPkHvRDBLCiBGyWwppibDUvN+tYdvlhtn1UDsYZaHRXSl6cow/1ILE/DOwH3Vg==",
+      "license": "ISC",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "pino": "8.20.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
-    "@govuk-one-login/frontend-ui": "1.3.9",
+    "@govuk-one-login/frontend-ui": "1.3.12",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.11.0",
     "cfenv": "1.2.4",


### PR DESCRIPTION

## Proposed changes

### What changed

- Bump `frontend-ui` package to include the FEC fixes

Before - currently in the stubs: 

https://github.com/user-attachments/assets/a04d6962-96e6-49f1-a0cf-0adeec1ea0b0


Now:

https://github.com/user-attachments/assets/56b3fa6a-3c73-4714-8522-c40db9ea42ad



### Why did it change

To enable branding changes.

### Issue tracking

- [OJ-3322](https://govukverify.atlassian.net/browse/OJ-3322)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3322]: https://govukverify.atlassian.net/browse/OJ-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ