### PR TITLE
OJ-3238: Remove text fields relating to footer and banners

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -8,55 +8,6 @@ govuk:
   error: "Gwall"
   warning: "Rhybudd"
   skipLink: "Neidio i'r prif gynnwys"
-  cookie:
-    cookieBanner:
-      title: "Cwcis ar GOV.UK One Login"
-      heading: "Cwcis ar GOV.UK One Login"
-      paragraph1: "Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio."
-      paragraph2: "Hoffem hefyd ddefnyddio cwcis dadansoddi er mwyn i ni allu deall sut rydych yn defnyddio'r gwasanaeth a gwneud gwelliannau."
-      buttonAcceptText: "Derbyn cwcis dadansoddi"
-      buttonRejectText: "Gwrthod cwcis dadansoddi"
-      linkViewCookiesText: "Gweld cwcis"
-      cookieBannerHideLink: "Cuddio'r neges yma"
-      cookieBannerAccept:
-        paragraph1: "Rydych wedi derbyn cwcis ychwanegol. Gallwch "
-        paragraph2: " unrhyw bryd."
-      cookieBannerReject:
-        paragraph1: "Rydych wedi gwrthod cwcis ychwanegol. Gallwch "
-        paragraph2: " unrhyw bryd."
-      changeCookiePreferencesLink: "newid eich gosodiadau cwcis"
-    cookieText: "Mae GOV.UK yn defnyddio cwcis i wneud y safle'n symlach."
-    cookieLink: "#"
-    cookieLinkText: "Darganfyddwch fwy am gwcis"
-  phaseBanner:
-    tag: "beta"
-    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i''w wella.'
-  languageToggle:
-    ariaLabel: Dewis iaith
-    englishLanguage: English
-    englishVisuallyHidden: Change to English
-    welshLanguage: Cymraeg
-    welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  footerNavItems:
-    meta:
-      items:
-        - href: "https://signin.account.gov.uk/accessibility-statement"
-          text: "Datganiad hygyrchedd"
-        - href: "https://signin.account.gov.uk/cookies"
-          text: "Cwcis"
-        - href: "https://signin.account.gov.uk/terms-and-conditions"
-          text: "Telerau ac amodau"
-        - href: "https://signin.account.gov.uk/privacy-notice"
-          text: "Hysbysiad preifatrwydd"
-        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
-          text: "Cymorth (agor mewn tab newydd)"
-          attributes:
-            rel: "noreferrer noopener"
-            target: "_blank"
-  copyright:
-    text: "© Hawlfraint y goron"
-  contentLicence:
-    html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="licence">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'
 error:
   unrecoverable:
     title: "Mae'n ddrwg gennym, mae problem"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -8,55 +8,6 @@ govuk:
   error: Error
   warning: Warning
   skipLink: Skip to main content
-  cookie:
-    cookieBanner:
-      title: "Cookies on GOV.UK One Login"
-      heading: "Cookies on GOV.UK One Login"
-      paragraph1: "We use some essential cookies to make this service work."
-      paragraph2: "We’d also like to use analytics cookies so we can understand how you use the service and make improvements."
-      buttonAcceptText: "Accept analytics cookies"
-      buttonRejectText: "Reject analytics cookies"
-      linkViewCookiesText: "View cookies"
-      cookieBannerHideLink: "Hide this message"
-      cookieBannerAccept:
-        paragraph1: "You’ve accepted additional cookies. You can "
-        paragraph2: " at any time."
-      cookieBannerReject:
-        paragraph1: "You’ve rejected additional cookies. You can "
-        paragraph2: " at any time."
-      changeCookiePreferencesLink: "change your cookie settings"
-    cookieText: "GOV.UK uses cookies to make the site simpler."
-    cookieLink: "#"
-    cookieLinkText: "Find out more about cookies"
-  phaseBanner:
-    tag: beta
-    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
-  languageToggle:
-    ariaLabel: Choose a language
-    englishLanguage: English
-    englishVisuallyHidden: Change to English
-    welshLanguage: Cymraeg
-    welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  footerNavItems:
-    meta:
-      items:
-        - href: https://signin.account.gov.uk/accessibility-statement
-          text: Accessibility statement
-        - href: https://signin.account.gov.uk/cookies
-          text: Cookies
-        - href: https://signin.account.gov.uk/terms-and-conditions
-          text: Terms and conditions
-        - href: https://signin.account.gov.uk/privacy-notice
-          text: Privacy notice
-        - href: https://home.account.gov.uk/contact-gov-uk-one-login
-          text: Support (opens in new tab)
-          attributes:
-            rel: "noreferrer noopener"
-            target: "_blank"
-  copyright:
-    text: "© Crown copyright"
-  contentLicence:
-    html: 'All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="licence">Open Government Licence v3.0</a>, except where otherwise stated'
 error:
   unrecoverable:
     title: Sorry, there is a problem with the service


### PR DESCRIPTION
### What changed

Remove text fields relating to rebranding in `default.yml` for both languages

<img width="1212" height="629" alt="image" src="https://github.com/user-attachments/assets/a54ce563-40b3-422e-ac93-ed2e8e080e92" />

<img width="1252" height="833" alt="image" src="https://github.com/user-attachments/assets/da67b7fc-b986-468b-9c5c-f7f470b7496d" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3238](https://govukverify.atlassian.net/browse/OJ-3238)