### PR TITLE
OJ-3330: Vulnerability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "uglify-js": "3.17.4"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "11.0.1",
+        "@cucumber/cucumber": "^11.3.0",
         "@eslint/eslintrc": "3.3.0",
         "@eslint/js": "9.21.0",
         "chai": "4.4.1",
@@ -983,6 +983,8 @@
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -996,23 +998,26 @@
       "license": "MIT"
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "11.0.1",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-11.3.0.tgz",
+      "integrity": "sha512-1YGsoAzRfDyVOnRMTSZP/EcFsOBElOKa2r+5nin0DJAeK+Mp0mzjcmSllMgApGtck7Ji87wwy3kFONfHUHMn4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cucumber/ci-environment": "10.0.1",
-        "@cucumber/cucumber-expressions": "17.1.0",
-        "@cucumber/gherkin": "28.0.0",
+        "@cucumber/cucumber-expressions": "18.0.1",
+        "@cucumber/gherkin": "30.0.4",
         "@cucumber/gherkin-streams": "5.0.1",
-        "@cucumber/gherkin-utils": "9.0.0",
-        "@cucumber/html-formatter": "21.6.0",
+        "@cucumber/gherkin-utils": "9.2.0",
+        "@cucumber/html-formatter": "21.10.1",
+        "@cucumber/junit-xml-formatter": "0.7.1",
         "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "24.1.0",
-        "@cucumber/tag-expressions": "6.1.0",
+        "@cucumber/messages": "27.2.0",
+        "@cucumber/tag-expressions": "6.1.2",
         "assertion-error-formatter": "^3.0.0",
         "capital-case": "^1.0.4",
         "chalk": "^4.1.2",
-        "cli-table3": "0.6.3",
+        "cli-table3": "0.6.5",
         "commander": "^10.0.0",
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
@@ -1025,41 +1030,59 @@
         "knuth-shuffle-seeded": "^1.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "luxon": "3.2.1",
+        "luxon": "3.6.1",
         "mime": "^3.0.0",
         "mkdirp": "^2.1.5",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
-        "read-pkg-up": "^7.0.1",
-        "resolve-pkg": "^2.0.0",
-        "semver": "7.5.3",
+        "read-package-up": "^11.0.0",
+        "semver": "7.7.1",
         "string-argv": "0.3.1",
-        "strip-ansi": "6.0.1",
         "supports-color": "^8.1.1",
-        "tmp": "0.2.3",
-        "type-fest": "^4.8.3",
+        "type-fest": "^4.41.0",
         "util-arity": "^1.1.0",
-        "xmlbuilder": "^15.1.1",
         "yaml": "^2.2.2",
-        "yup": "1.2.0"
+        "yup": "1.6.1"
       },
       "bin": {
         "cucumber-js": "bin/cucumber.js"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "18 || 20 || 22 || >=23"
       },
       "funding": {
         "url": "https://opencollective.com/cucumber"
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "17.1.0",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.0.1.tgz",
+      "integrity": "sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/@cucumber/messages": {
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
+      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.0.5"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cucumber/cucumber/node_modules/glob": {
       "version": "10.4.5",
@@ -1108,19 +1131,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@cucumber/cucumber/node_modules/semver": {
-      "version": "7.5.3",
+    "node_modules/@cucumber/cucumber/node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+      "license": "Apache-2.0"
     },
     "node_modules/@cucumber/cucumber/node_modules/supports-color": {
       "version": "8.1.1",
@@ -1137,7 +1153,9 @@
       }
     },
     "node_modules/@cucumber/cucumber/node_modules/type-fest": {
-      "version": "4.30.0",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -1147,12 +1165,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@cucumber/cucumber/node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@cucumber/gherkin": {
-      "version": "28.0.0",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-30.0.4.tgz",
+      "integrity": "sha512-pb7lmAJqweZRADTTsgnC3F5zbTh3nwOB1M83Q9ZPbUKMb3P76PzK6cTcPTJBHWy3l7isbigIv+BkDjaca6C8/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <=24"
+        "@cucumber/messages": ">=19.1.4 <=26"
       }
     },
     "node_modules/@cucumber/gherkin-streams": {
@@ -1181,34 +1215,134 @@
       }
     },
     "node_modules/@cucumber/gherkin-utils": {
-      "version": "9.0.0",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-9.2.0.tgz",
+      "integrity": "sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/gherkin": "^28.0.0",
-        "@cucumber/messages": "^24.0.0",
+        "@cucumber/gherkin": "^31.0.0",
+        "@cucumber/messages": "^27.0.0",
         "@teppeis/multimaps": "3.0.0",
-        "commander": "12.0.0",
+        "commander": "13.1.0",
         "source-map-support": "^0.5.21"
       },
       "bin": {
         "gherkin-utils": "bin/gherkin-utils"
       }
     },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
+      "integrity": "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <=26"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
+      "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "10.0.0"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/messages": {
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
+      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.0.5"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@cucumber/gherkin-utils/node_modules/commander": {
-      "version": "12.0.0",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@cucumber/gherkin-utils/node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@cucumber/html-formatter": {
-      "version": "21.6.0",
+      "version": "21.10.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.10.1.tgz",
+      "integrity": "sha512-isaaNMNnBYThsvaHy7i+9kkk9V3+rhgdkt0pd6TCY6zY1CSRZQ7tG6ST9pYyRaECyfbCeF7UGH0KpNEnh6UNvQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@cucumber/messages": ">=18"
+      }
+    },
+    "node_modules/@cucumber/junit-xml-formatter": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.7.1.tgz",
+      "integrity": "sha512-AzhX+xFE/3zfoYeqkT7DNq68wAQfBcx4Dk9qS/ocXM2v5tBv6eFQ+w8zaSfsktCjYzu4oYRH/jh4USD1CYHfaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/query": "^13.0.2",
+        "@teppeis/multimaps": "^3.0.0",
+        "luxon": "^3.5.0",
+        "xmlbuilder": "^15.1.1"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
       }
     },
     "node_modules/@cucumber/message-streams": {
@@ -1230,8 +1364,24 @@
         "uuid": "9.0.1"
       }
     },
+    "node_modules/@cucumber/query": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-13.6.0.tgz",
+      "integrity": "sha512-tiDneuD5MoWsJ9VKPBmQok31mSX9Ybl+U4wqDoXeZgsXHDURqzM3rnpWVV3bC34y9W6vuFxrlwF/m7HdOxwqRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@teppeis/multimaps": "3.0.0",
+        "lodash.sortby": "^4.7.0"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
     "node_modules/@cucumber/tag-expressions": {
-      "version": "6.1.0",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.1.2.tgz",
+      "integrity": "sha512-xa3pER+ntZhGCxRXSguDTKEHTZpUUsp+RzTRNnit+vi5cqnk6abLdSLg5i3HZXU3c74nQ8afQC6IT507EN74oQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2522,6 +2672,8 @@
     },
     "node_modules/@teppeis/multimaps": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
+      "integrity": "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2593,6 +2745,8 @@
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3502,7 +3656,9 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.3",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5127,6 +5283,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "dev": true,
@@ -6168,6 +6337,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+      "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "license": "ISC",
@@ -6860,7 +7042,8 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -6924,11 +7107,6 @@
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
       }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "15.2.10",
@@ -7136,6 +7314,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "dev": true,
@@ -7305,18 +7490,15 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/luxon": {
-      "version": "3.2.1",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8411,10 +8593,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "license": "MIT"
@@ -8671,6 +8849,8 @@
     },
     "node_modules/property-expr": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8809,6 +8989,116 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-up/node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-up/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "dev": true,
@@ -8820,61 +9110,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/parse-json": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/readable-stream": {
@@ -8966,6 +9201,8 @@
     },
     "node_modules/regexp-match-indices": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+      "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8974,6 +9211,8 @@
     },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9060,17 +9299,6 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-pkg": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -9300,7 +9528,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9996,16 +10226,10 @@
     },
     "node_modules/tiny-case": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -10026,6 +10250,8 @@
     },
     "node_modules/toposort": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10669,6 +10895,8 @@
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10774,7 +11002,9 @@
       }
     },
     "node_modules/yup": {
-      "version": "1.2.0",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10786,6 +11016,8 @@
     },
     "node_modules/yup/node_modules/type-fest": {
       "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "11.0.1",
+    "@cucumber/cucumber": "11.3.0",
     "@eslint/eslintrc": "3.3.0",
     "@eslint/js": "9.21.0",
     "chai": "4.4.1",


### PR DESCRIPTION
## Proposed changes

Fix dependabot vulnerability by updating @cucumber/cucumber version which doesn't seem to depend on tmp

### What changed

Vulnerability highlighted as a result of

```
 Transitive dependency tmp 0.2.3 is introduced via
@cucumber/cucumber 9.5.1  tmp 0.2.3
```


### Why did it change

see: https://github.com/orgs/govuk-one-login/security/alerts/dependabot?q=is:open%20props.pod:Identity%20team:cri-orange-team

https://github.com/govuk-one-login/ipv-cri-kbv-front/security/dependabot/65

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3330](https://govukverify.atlassian.net/browse/OJ-3330)


[OJ-3330]: https://govukverify.atlassian.net/browse/OJ-3330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ