### PR TITLE
use stack name in KbvFrontSessionsTable name

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -389,9 +389,7 @@ Resources:
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
             - Name: SESSION_TABLE_NAME
-              Value: !Sub
-                - "cri-kbv-front-sessions-${Environment}"
-                - Environment: !Ref Environment
+              Value: !Ref KbvFrontSessionsTable
             - Name: UA_CONTAINER_ID
               Value: !If [IsProduction, "GTM-TT5HDKV", "GTM-TK92W68"]
             - Name: GA4_CONTAINER_ID
@@ -860,7 +858,10 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
-      TableName: !Sub "cri-kbv-front-sessions-${Environment}"
+      TableName: !If
+        - IsNotDevelopment
+        - !Sub "cri-kbv-front-sessions-${Environment}"
+        - !Sub "${AWS::StackName}-cri-kbv-front-sessions-${Environment}"
       BillingMode: "PAY_PER_REQUEST"
       AttributeDefinitions:
         - AttributeName: "id"


### PR DESCRIPTION
## Proposed changes

### What changed
use stack name in KbvFrontSessionsTable name for dev environment.

### Why did it change
so that we can create multiple FE stacks without the table name conflicting as it will already exist for the main stack.

* New session table created and the old one has been deleted in dev
* FE still works via core stub

<img width="1274" height="683" alt="Screenshot 2025-09-15 at 11 58 21" src="https://github.com/user-attachments/assets/a77064c0-b21e-42fe-a5d8-2982c3e5a016" />

<img width="1511" height="816" alt="Screenshot 2025-09-15 at 11 58 55" src="https://github.com/user-attachments/assets/0a09d9d9-85cd-4c2d-b548-32a6fece3482" />

### Issue tracking
- [OJ-3424](https://govukverify.atlassian.net/browse/OJ-3424)

[OJ-3424]: https://govukverify.atlassian.net/browse/OJ-3424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ