### PR TITLE
chore: bump axios version to 1.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
         "@govuk-one-login/frontend-ui": "1.3.12",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
-        "axios": "1.11.0",
+        "axios": "1.12.2",
         "cfenv": "1.2.4",
         "connect-dynamodb": "^2.0.4",
         "copyfiles": "2.4.1",
@@ -34,7 +34,7 @@
         "uglify-js": "3.17.4"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^11.3.0",
+        "@cucumber/cucumber": "11.3.0",
         "@eslint/eslintrc": "3.3.0",
         "@eslint/js": "9.21.0",
         "chai": "4.4.1",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
     "@govuk-one-login/frontend-ui": "1.3.12",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
-    "axios": "1.11.0",
+    "axios": "1.12.2",
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.4",
     "copyfiles": "2.4.1",


### PR DESCRIPTION
## Proposed changes

### What changed
bump axios version to 1.12.2

### Why did it change
Critical vulnerability fix: https://github.com/govuk-one-login/ipv-cri-kbv-front/security/dependabot/67

### Issue tracking
- [OJ-3346](https://govukverify.atlassian.net/browse/OJ-3346)



[OJ-3346]: https://govukverify.atlassian.net/browse/OJ-3346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ