### PR TITLE
OJ-3356: Enable drop_invalid_header_fields on ALB

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -219,15 +219,24 @@ Resources:
         - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
         - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
       Type: application
-      LoadBalancerAttributes: !If
-        - IsNotDevelopment
-        - - Key: access_logs.s3.enabled
+      LoadBalancerAttributes:
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: true
+        - !If
+          - IsNotDevelopment
+          - Key: access_logs.s3.enabled
             Value: true
+          - !Ref AWS::NoValue
+        - !If
+          - IsNotDevelopment
           - Key: access_logs.s3.bucket
             Value: !Ref AccessLogsBucket
+          - !Ref AWS::NoValue
+        - !If
+          - IsNotDevelopment
           - Key: access_logs.s3.prefix
             Value: !Sub kbv-front-${Environment}
-        - !Ref AWS::NoValue
+          - !Ref AWS::NoValue
       Tags:
         - Key: FMSRegionalPolicy
           Value: false


### PR DESCRIPTION
## Proposed changes

### What changed

- Enabled drop_invalid_header_fields on frontend ALB

### Why did it change

- This setting checks that header names conform to `[-A-Za-z0-9]+` and drops any that do not. This is beneficial as it will protect the frontend application from potentially unsafe header keys.

### Issue tracking

- OJ-3356

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
