### PR TITLE
OJ-3337: Set ReadonlyRootFilesystem on ECS container

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -388,6 +388,7 @@ Resources:
         - Essential: true
           Image: CONTAINER-IMAGE-PLACEHOLDER
           Name: app
+          ReadonlyRootFilesystem: true
           Environment:
             - Name: API_BASE_URL
               Value: !Sub


### PR DESCRIPTION
## Proposed changes

### What changed

- Enabled 'ReadonlyRootFilesystem' setting on the frontend host ECS container

### Why did it change

This makes the container more secure as the filesystem (and therefore source code and system files) cannot be written to at runtime.

### Issue tracking

- [OJ-3337](https://govukverify.atlassian.net/browse/OJ-3337)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

### Test evidence

<img width="1569" height="1065" alt="image" src="https://github.com/user-attachments/assets/693bea2b-b989-4a2e-b426-5366b39391d0" />

<img width="1487" height="672" alt="image" src="https://github.com/user-attachments/assets/3f773f36-14c2-437a-a180-9682e0efeb8b" />

[OJ-3337]: https://govukverify.atlassian.net/browse/OJ-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ