### PR TITLE
OJ-3355: Update AccessLogsBucketPolicy to Deny http unsecure request

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -202,6 +202,18 @@ Resources:
               - s3:PutObject
             Resource:
               - !Sub arn:aws:s3:::${AccessLogsBucket}/kbv-front-${Environment}/AWSLogs/${AWS::AccountId}/*
+          - Effect: Deny
+            Resource:
+              - !GetAtt AccessLogsBucket.Arn
+              - !Sub "${AccessLogsBucket.Arn}/*"
+            Principal: "*"
+            Action:
+              - "s3:*"
+            Condition:
+              Bool:
+                "aws:SecureTransport": false
+              NumericLessThan:
+                "s3:TlsVersion": "1.2"
 
   CloudFrontWAFv2ACLAssociation:
     Type: AWS::WAFv2::WebACLAssociation


### PR DESCRIPTION
## Proposed changes

S3 buckets should have policies that require requests to use SSL/TLS, by having a policy that denies HTTP requests. 

### Why did it change

This means that data in transit is encrypted which is a security best practise https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit 

- [OJ-3355](https://govukverify.atlassian.net/browse/OJ-3355)



[OJ-3355]: https://govukverify.atlassian.net/browse/OJ-3355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ