### PR TITLE
OJ-3445: Add FMSGlobalCustomPolicy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -55,6 +55,8 @@ Conditions:
     - !Equals [!Ref Environment, production]
     - !Equals [!Ref Environment, integration]
 
+  IsNotProductionOrIntegration: !Not [!Condition IsProductionOrIntegration]
+
   IsBuildOrDev: !Or
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, dev]
@@ -255,6 +257,11 @@ Resources:
       Tags:
         - Key: FMSRegionalPolicy
           Value: false
+        - !If
+          - IsNotProductionOrIntegration
+          - Key: CustomPolicy
+            Value: "true"
+          - !Ref AWS::NoValue
 
   LoadBalancerListenerTargetGroupECS:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -628,6 +635,12 @@ Resources:
     Properties:
       Name: !Sub KBV-front-${Environment}
       ProtocolType: HTTP
+      Tags:
+        FMSRegionalPolicy: false
+        CustomPolicy: !If
+          - IsNotProductionOrIntegration
+          - "true"
+          - !Ref AWS::NoValue
 
   ApiGwHttpEndpointIntegration:
     Type: AWS::ApiGatewayV2::Integration
@@ -672,6 +685,12 @@ Resources:
           "responseLength":"$context.responseLength",
           "responseLatency":"$context.responseLatency"
           }
+      Tags:
+        FMSRegionalPolicy: false
+        CustomPolicy: !If
+          - IsNotProductionOrIntegration
+          - "true"
+          - !Ref AWS::NoValue
 
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope. In COUNT mode FMS merely logs the rule violations, in BLOCK mode violating requests are actively blocked. 

The tags to implement this should only apply (conditionally) to resources deployed to dev, build and staging accounts. The tags must not apply to int and prod (there is a follow-up ticket for this:

### What changed

Apply tagging conditional to meet the above requirement

### Why did it change

**Tags On Load Balancer**

<img width="1202" height="706" alt="image" src="https://github.com/user-attachments/assets/780dcdca-27c9-4a81-ac01-70c9977a9247" />

**Tags on ApiGateway**
<img width="1192" height="736" alt="image" src="https://github.com/user-attachments/assets/e0a5255c-6a0b-40e4-8202-94e9aaa564cf" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3445(https://govukverify.atlassian.net/browse/OJ-3445)
