### PR TITLE
OJ-3614: redirect to done when no question in session on configure

### DIFF
--- a/src/app/kbv/controllers/question.js
+++ b/src/app/kbv/controllers/question.js
@@ -11,7 +11,7 @@ const { API } = require("../../../lib/config");
 class QuestionController extends BaseController {
   configure(req, res, next) {
     if (!req.session.question) {
-      return next(new Error("Current session has no Question to configure."));
+      return res.redirect(`${req.baseUrl}/done`);
     }
     const fallbackTranslations = dynamicQuestion.questionToTranslations(
       req.session.question

--- a/src/app/kbv/controllers/question.test.js
+++ b/src/app/kbv/controllers/question.test.js
@@ -90,7 +90,9 @@ describe("Question controller", () => {
         fields: {},
       };
 
+      req.baseUrl = "/kbv";
       req.session.question = undefined;
+      res.redirect = sinon.fake();
 
       prototypeSpy = sinon.stub(BaseController.prototype, "configure");
       BaseController.prototype.configure.callThrough();
@@ -126,17 +128,8 @@ describe("Question controller", () => {
       expect(prototypeSpy).to.not.have.been.calledWith(req, res, next);
     });
 
-    it("should call next with an error", () => {
-      expect(next).to.have.been.calledWith(
-        sinon.match
-          .instanceOf(Error)
-          .and(
-            sinon.match.has(
-              "message",
-              "Current session has no Question to configure."
-            )
-          )
-      );
+    it("should redirect to done", () => {
+      expect(res.redirect).to.have.been.calledWith("/kbv/done");
     });
   });
 


### PR DESCRIPTION
## Proposed changes

### What changed
When there are are no questions available redirect to /done so the flow proceeds normally to `/oauth2/callback` instead of the error path. 

### Why did it change
Currently our KBV CRI FE is throwing an error in the code when no questions are returned for a user from Experian. This lead to an [alert being flagged in the 2nd line channel](https://gds.slack.com/archives/C02HCLREVV5/p1773400428973469) for an error in Experian KBV. 

This is a valid flow, hence, we need to ensure when this happens no error appears

### Issue tracking
- [OJ-3614](https://govukverify.atlassian.net/browse/OJ-3614)


[OJ-3614]: https://govukverify.atlassian.net/browse/OJ-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ