### PR TITLE
OJ-3606: Fix page not found error page

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -17,6 +17,15 @@ error:
     contactMeLink: "Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)"
     buttonText: "Ewch i hafan GOV.UK"
     buttonLink: "https://www.gov.uk/"
+  pageNotFound:
+    title: "Tudalen heb ei darganfod"
+    serviceNameRequired: false
+    content:
+      - "Os ydych wedi teipio’r cyfeiriad gwe, edrychwch i weld ei fod yn gywir."
+      - "Os ydych wedi gludo’r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo’r cyfeiriad cyfan."
+      - "Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddi’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
+      - '<a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>'
+      - '<a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Cysylltu â thîm GOV.UK One Login (agor mewn tab newydd)</a>'
 validation:
   required: "Mae angen i chi ateb y cwestiwn"
 answers:

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -15,6 +15,8 @@ check:
 error:
   unrecoverable:
     title: "Mae'n ddrwg gennym, mae problem"
+  pageNotFound:
+    title: "Tudalen heb ei darganfod"
 simplifiedQuestion:
   abandon: "Nid wyf yn gwybod yr ateb i'r cwestiwn hwn"
   abandonBody: "Os na allwch ateb cwestiwn, bydd angen i chi <a href='/kbv/abandon' class='govuk-link' data-id='abandon'>brofi eich hunaniaeth mewn ffordd arall</a>.<br><br>Ni allwch hepgor unrhyw gwestiynau."

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -17,6 +17,15 @@ error:
     contactMeLink: Contact the GOV.UK One Login team (opens in a new tab)
     buttonText: Go to the GOV.UK homepage
     buttonLink: https://www.gov.uk/
+  pageNotFound:
+    title: Page not found
+    serviceNameRequired: false
+    content:
+      - If you typed the web address, check it’s correct.
+      - If you pasted the web address, check you copied the entire address.
+      - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
+      - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
+      - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
 validation:
   required: "You need to answer the question"
 answers:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -16,6 +16,8 @@ check:
 error:
   unrecoverable:
     title: Sorry, there is a problem with the service
+  pageNotFound:
+    title: Page not found
 
 simplifiedQuestion:
   abandon: "I do not know the answer to this question"

--- a/src/views/errors/page-not-found.njk
+++ b/src/views/errors/page-not-found.njk
@@ -1,14 +1,29 @@
 {% extends "base-page.njk" %}
-{% set hmpoPageKey = "errors.pageNotFound" %}
-{% from "components/onPageLoad/macro.njk" import ga4OnPageLoad %}
 
-{{ ga4OnPageLoad({
-  nonce: cspNonce,
-  statusCode: '404',
-  englishPageTitle: 'pageNotFound.title' | translate,
-  taxonomyLevel1: 'web cri',
-  taxonomyLevel2: 'kbv',
-  contentId: 'undefined',
-  loggedInStatus: true,
-  dynamic: false
-}) }}
+{% set hmpoPageKey = "error.pageNotFound" %}
+
+{% set isPageDataSensitive = false %}
+{% set statusCode = '404' %}
+{% set pageTitleKey = "pages.pageNotFound.title" %}
+{% set contentID = "004" %}
+{% set taxLevel2 = 'page-not-found' %}
+{% set isPageDynamic = false %}
+{% set loggedInStatus = true %}
+
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+
+{% block mainContent %}
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+        {{ translate(hmpoPageKey+'.title', { default: [] }) | safe }}
+    </h1>
+
+    {{ hmpoHtml(translate(hmpoPageKey + ".content", { default: [] })) }}
+{% endblock %}
+
+{% block scripts %}
+    <script type="text/javascript" nonce='{{cspNonce}}'>
+        window.DI = window.DI || {};
+        window.DI.httpStatusCode = 404
+    </script>
+    {{ super ()}}
+{% endblock %}

--- a/test/browser/features/errors.feature
+++ b/test/browser/features/errors.feature
@@ -26,3 +26,11 @@ Feature: Error handling
     And they should see the first question
     When they answer the first question
     Then they should be redirected as an error
+
+  @mock-api:question-success
+  Scenario: Error - Page not found
+    Given they have started the KBV journey
+    And they have continued to questions
+    And they should see the first question
+    When they go to an unknown page
+    Then they should see the Page not found error page

--- a/test/browser/pages/error.js
+++ b/test/browser/pages/error.js
@@ -10,6 +10,10 @@ module.exports = class PlaywrightDevPage {
     return this.page.textContent('[data-id="error-title"]');
   }
 
+  getPageHeader() {
+    return this.page.textContent("#header");
+  }
+
   getSomethingWentWrongMessage() {
     return "Sorry, there is a problem with the service";
   }
@@ -30,5 +34,9 @@ module.exports = class PlaywrightDevPage {
 
   isCurrentPage() {
     return this.page.url() === this.url;
+  }
+
+  async goToPage(pageName) {
+    await this.page.goto(this.page.url() + pageName);
   }
 };

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -13,3 +13,14 @@ Then("they should see the unrecoverable error page", async function () {
 
   expect(errorTitle).to.equal(errorPage.getSomethingWentWrongMessage());
 });
+
+When("they go to an unknown page", async function () {
+  const errorPage = new ErrorPage(this.page);
+  await errorPage.goToPage("not-going-to-be-found");
+});
+
+Then("they should see the Page not found error page", async function () {
+  const errorPage = new ErrorPage(this.page);
+  const errorPageHeader = await errorPage.getPageHeader();
+  expect(errorPageHeader).to.contain("Page not found");
+});


### PR DESCRIPTION
## Proposed changes

### What changed

- Moved `pageNotFound` translations location
- Refactored the page to now render the content we want with the analytics. 
- Added browser test

### Why did it change

404 pages were not displaying correctly. 

### Issue tracking

- [OJ-3606](https://govukverify.atlassian.net/browse/OJ-3606)

[OJ-3606]: https://govukverify.atlassian.net/browse/OJ-3606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ