### PR TITLE
OJ-3747: New post-merge GHA

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -1,8 +1,6 @@
 name: Docker build, ECR push, template copy to S3
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -1,8 +1,6 @@
 name: Development Docker build, ECR push, template copy to S3
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,28 @@
+name: Post merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  scan-and-unit-test:
+    name: Scan repo
+    uses: ./.github/workflows/scan-repo.yml
+    secrets: inherit
+
+  deploy-dev:
+    name: Package for dev
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-to-dev.yml
+    secrets: inherit
+
+  deploy-build:
+    name: Package for build
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-to-build.yml
+    secrets: inherit

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -3,8 +3,7 @@ name: Scan repository
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
   schedule:
     # Every Monday at 9am
     - cron: "0 9 * * 1"
@@ -13,7 +12,8 @@ concurrency:
   group: scan-repo-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   coverage:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,8 @@
       "path": "detect_secrets.filters.regex.should_exclude_secret",
       "pattern": [
         "ewogICJhbGciOiAiRVMyNTYiLAogICJ1c2UiOiAi*",
-        "API_KEY_CRI_DEV"
+        "API_KEY_CRI_DEV",
+        "inherit"
       ]
     }
   ],


### PR DESCRIPTION
## Proposed changes

### What changed

Created a new `post-merge.yml `GHA. 

### Why did it change

We previously deployed even if scan-repo failed post-merge. This now makes deploying depend on scan-repo completing successfully.

### Issue tracking

- [OJ-3747](https://govukverify.atlassian.net/browse/OJ-3747)

[OJ-3747]: https://govukverify.atlassian.net/browse/OJ-3747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ