### PR TITLE
OJ-3805: Bump frontend-analytics to v4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
         "@govuk-one-login/di-ipv-cri-common-express": "16.2.1",
-        "@govuk-one-login/frontend-analytics": "4.0.5",
+        "@govuk-one-login/frontend-analytics": "4.2.0",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
@@ -1549,9 +1549,10 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-analytics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.0.5.tgz",
-      "integrity": "sha512-6JU8TQIXByxYQqV2b2sEy9eqM59Fwin3GqFXXSemtE7knxQ76YBJsVOgSTBrgCsjQ3DAbcZAUNLLopD9qBioYg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.2.0.tgz",
+      "integrity": "sha512-6CnKHdzZkgtFLnHe0NQM1atgq6oV1KMKF8eBewuG5hvW2Lio0+otr/18pw0uXimyJs0uz0nPdvdM2Fh+9WYrRw==",
+      "license": "MIT",
       "dependencies": {
         "loglevel": "^1.9.2"
       }
@@ -1669,15 +1670,6 @@
         "@govuk-one-login/frontend-analytics": " ^3.0.1 || ^4.0.3",
         "express": "^5.1.0 || >= 4.21.2",
         "govuk-frontend": "^4.10.1 || ^5.0.0"
-      }
-    },
-    "node_modules/@govuk-one-login/frontend-ui/node_modules/@govuk-one-login/frontend-analytics": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.0.7.tgz",
-      "integrity": "sha512-G78BF00pluhlxATx8Gc3/wejDPg2yf2wMQPCIV6l0uotuh0wb81Qw+j7IN+rsDNMzwvtKxFpAmjKcfxJZPXh7w==",
-      "optional": true,
-      "dependencies": {
-        "loglevel": "^1.9.2"
       }
     },
     "node_modules/@govuk-one-login/frontend-ui/node_modules/hmpo-components": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
     "@govuk-one-login/di-ipv-cri-common-express": "16.2.1",
-    "@govuk-one-login/frontend-analytics": "4.0.5",
+    "@govuk-one-login/frontend-analytics": "4.2.0",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",


### PR DESCRIPTION
## Proposed changes

### What changed

- Bumped `@govuk-one-login/frontend-analytics` to v4.2.0

### Why did it change

- The current version has a known issue that causes PII to be leaked to analytics platforms

### Issue tracking

- OJ-3805

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
