### PR TITLE
OJ-3668: feat - update scaling policy to 30% threshold and policies t…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -104,7 +104,7 @@ Mappings:
     build:
       logLevel: "info"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 6
+      minECSCount: 2
       maxECSCount: 60
     staging:
       logLevel: "warn"
@@ -784,7 +784,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 30
+        TargetValue: 25
         ScaleInCooldown: 420
         ScaleOutCooldown: 60
 
@@ -802,7 +802,7 @@ Resources:
         MetricSpecifications:
           - PredefinedMetricPairSpecification:
               PredefinedMetricType: ECSServiceCPUUtilization
-            TargetValue: 30
+            TargetValue: 25
         Mode: ForecastOnly
         SchedulingBufferTime: 600
 
@@ -819,11 +819,11 @@ Resources:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 300
         StepAdjustments:
-          - MetricIntervalUpperBound: 0
+          - MetricIntervalUpperBound: -10
             MetricIntervalLowerBound: -20
             ScalingAdjustment: -10
           - MetricIntervalUpperBound: -20
-            ScalingAdjustment: -20
+            ScalingAdjustment: -50
 
   StepScaleOutPolicy:
     DependsOn: ECSAutoScalingTarget

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -104,7 +104,7 @@ Mappings:
     build:
       logLevel: "info"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 2
+      minECSCount: 6
       maxECSCount: 60
     staging:
       logLevel: "warn"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -104,7 +104,7 @@ Mappings:
     build:
       logLevel: "info"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 3
+      minECSCount: 6
       maxECSCount: 60
     staging:
       logLevel: "warn"
@@ -784,7 +784,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 60.0
+        TargetValue: 30
         ScaleInCooldown: 420
         ScaleOutCooldown: 60
 
@@ -819,11 +819,11 @@ Resources:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 300
         StepAdjustments:
-          - MetricIntervalUpperBound: -10
+          - MetricIntervalUpperBound: 0
             MetricIntervalLowerBound: -20
             ScalingAdjustment: -10
           - MetricIntervalUpperBound: -20
-            ScalingAdjustment: -50
+            ScalingAdjustment: -20
 
   StepScaleOutPolicy:
     DependsOn: ECSAutoScalingTarget
@@ -857,14 +857,14 @@ Resources:
       AlarmName: !Sub ${AWS::StackName}-${Environment}-ExperianKBVStepScaleOutAlarm
       AlarmDescription: "Experian KBV front cluster over 30 percent CPU."
       ComparisonOperator: "GreaterThanThreshold"
-      DatapointsToAlarm: "2"
+      DatapointsToAlarm: "1"
       Dimensions:
         - Name: ClusterName
           Value: !Ref KBVFrontEcsCluster
         - Name: ServiceName
           Value: !GetAtt KBVFrontEcsService.Name
       Unit: "Percent"
-      EvaluationPeriods: "2"
+      EvaluationPeriods: "1"
       MetricName: "CPUUtilization"
       Namespace: "AWS/ECS"
       Statistic: "Average"


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Update minECSCount back to 6 in build
- Reduce scaling target value to 25 for scale.
- Reduce scale out alarms data point to 1 instead of 2 to alarm/scale faster.

### Why did it change

A frontend scaling policy decides how the servers that host our frontends scale up and down with demand. As demand increases, we want to spin up more machines for the frontend to ensure that all users get a good experience, and as it falls we want to scale back down to save money.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3668](https://govukverify.atlassian.net/browse/OJ-3668)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[OJ-3668]: https://govukverify.atlassian.net/browse/OJ-3668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ